### PR TITLE
Updated latest so that it builds and runs on DE

### DIFF
--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/datascience-notebook:latest
+FROM jupyter/datascience-notebook:lab-3.4.2
 
 USER root
 
@@ -6,19 +6,20 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Install a few dependencies for iCommands, text editing, and monitoring instances
 RUN apt update && \
-    apt install -y lsb-release apt-transport-https curl gnupg2 libfuse2 gcc less nodejs software-properties-common apt-utils glances htop nano  
+    apt install -y lsb-release apt-transport-https curl gnupg2 libfuse2 gettext gcc less nodejs software-properties-common apt-utils glances htop nano
+
 
 RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
-    echo "deb [arch=amd64] https://packages.irods.org/apt/ bionic main" > /etc/apt/sources.list.d/renci-irods.list && \
+    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/renci-irods.list && \
     apt update && \
     wget -q -c \
     http://security.ubuntu.com/ubuntu/pool/main/p/python-urllib3/python-urllib3_1.22-1ubuntu0.18.04.2_all.deb \
     http://security.ubuntu.com/ubuntu/pool/main/r/requests/python-requests_2.18.4-2ubuntu0.1_all.deb \
-    http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.8_amd64.deb && \
+    http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.10_amd64.deb && \
     apt install -y \
     ./python-urllib3_1.22-1ubuntu0.18.04.2_all.deb \
     ./python-requests_2.18.4-2ubuntu0.1_all.deb \
-    ./libssl1.0.0_1.0.2n-1ubuntu5.8_amd64.deb && \
+    ./libssl1.0.0_1.0.2n-1ubuntu5.10_amd64.deb && \
     rm -rf \
     ./python-urllib3_1.22-1ubuntu0.18.04.2_all.deb \
     ./python-requests_2.18.4-2ubuntu0.1_all.deb \
@@ -53,7 +54,7 @@ COPY jupyter_notebook_config.json /opt/conda/etc/jupyter/jupyter_notebook_config
 # Add sudo to jovyan user
 RUN apt update && \
     apt install -y sudo 
-    
+
 ARG LOCAL_USER=jovyan
 ARG PRIV_CMDS='/bin/ch*,/bin/cat,/bin/gunzip,/bin/tar,/bin/mkdir,/bin/ps,/bin/mv,/bin/cp,/usr/bin/apt*,/usr/bin/pip*,/bin/yum'
 

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -81,6 +81,9 @@ USER root
 RUN jupyter serverextension enable --py jupyterlab_irods
 RUN jupyter labextension install ijab
 
+RUN addgroup jovyan
+RUN usermod -aG jovyan jovyan
+
 USER jovyan
 
 EXPOSE 8888


### PR DESCRIPTION
Set the Jupyterlab-data science notebook from the latest to 3.4.2, updated OpenSSL version (previous version no longer available), and added RUN statements (copied from [Jupyterlab datasciene vice dockerfile](https://github.com/cyverse-vice/jupyterlab-datascience/blob/12624ccdc92255f1e5ab3a25ba9515d20d44c4e2/latest/Dockerfile) creating a user group to fix issues in the DE where the terminal couldn't find the user group 1000