### PR TITLE
Add image security scanning + wire vice-toolkit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "extraKnownMarketplaces": {
+    "cyverse-vice": { "source": { "source": "github", "repo": "cyverse-vice/vice-toolkit" } }
+  },
+  "enabledPlugins": { "vice-toolkit@cyverse-vice": true }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Propagated from rstudio-verse / rstudio-geospatial (which already use this).
+# Keeps GitHub Actions versions current via automated PRs. Drop into
+# .github/dependabot.yml in repos that lack it.
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,55 @@
+# Image security scanning for a CyVerse VICE image (scaffolded by vice-toolkit).
+# hadolint lints the Dockerfile on every PR; trivy scans the published Harbor
+# image weekly + on demand (not rebuilt per PR). Report-only by default.
+name: security
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint Dockerfile (hadolint)
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: latest/Dockerfile
+          config: .hadolint.yaml
+          failure-threshold: warning
+          no-fail: true            # report-only — set false to gate the PR
+
+  scan:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to Harbor
+        uses: docker/login-action@v3
+        with:
+          registry: harbor.cyverse.org
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+      - name: Scan published image for CVEs (trivy)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: harbor.cyverse.org/vice/jupyter/pytorch:latest
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '0'           # report-only — set '1' to gate on fixable findings
+        env:
+          TRIVY_TIMEOUT: 20m
+      - name: Upload results to the GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-latest

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,16 @@
+# hadolint config for CyVerse VICE Dockerfiles.
+# Start permissive, tighten over time. Remove an ignore once every repo's
+# Dockerfiles satisfy that rule. Docs: https://github.com/hadolint/hadolint
+failure-threshold: warning
+ignored:
+  - DL3008  # pin apt package versions — VICE images intentionally track latest base packages
+  - DL3013  # pin pip versions — same rationale
+  - DL3009  # delete the apt-get lists — REMOVE this ignore once all repos clean lists (rstudio-verse does not)
+  - DL4006  # set -o pipefail before pipes — noisy on simple RUN lines
+trustedRegistries:
+  - harbor.cyverse.org
+  - quay.io
+  - ghcr.io
+  - lscr.io
+  - docker.io
+  - nvcr.io

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,7 @@
+# Trivy ignore file. One CVE ID per line. ALWAYS add a justification comment.
+# Only suppress when a finding is unfixable AND accepted (e.g. inherited from the
+# upstream base with no fixed version and not exploitable in the VICE context).
+# Re-review on every weekly rebuild; delete entries once the base ships a fix.
+#
+# Example:
+# CVE-2023-12345  # accepted 2026-06: rocker base, no fixed version, not reachable in VICE

--- a/latest/.dockerignore
+++ b/latest/.dockerignore
@@ -1,0 +1,10 @@
+# Drop this into the active build-context directory (e.g. latest/.dockerignore).
+# Keeps repo metadata and editor cruft out of the image build context/layers.
+**/.git
+**/.github
+**/*.md
+**/LICENSE
+**/.gitignore
+**/.DS_Store
+**/*.swp
+**/.ipynb_checkpoints


### PR DESCRIPTION
Scaffolds CI security scanning and wires the `vice-toolkit` Claude Code plugin into this repo.

## What's here
- **`.github/workflows/security.yml`** (new): `hadolint` lints `latest/Dockerfile` on every PR; `trivy` scans the published image `harbor.cyverse.org/vice/jupyter/pytorch:latest` weekly + on demand (Harbor login + SARIF upload). Report-only.
- **`.hadolint.yaml` / `.trivyignore` / `latest/.dockerignore`** (new): scan/lint config.
- **`.github/dependabot.yml`** (new): GitHub Actions version updates.
- **`.claude/settings.json`** (new): auto-enables the [`cyverse-vice/vice-toolkit`](https://github.com/cyverse-vice/vice-toolkit) plugin.
- `harbor.yml` already meets the action-version standard — left unchanged.

Report-only (no PR gating). Draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
